### PR TITLE
small changes to support macos instantiation and build

### DIFF
--- a/FNAECSTemplate/CopyLibs.targets
+++ b/FNAECSTemplate/CopyLibs.targets
@@ -1,14 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+	<ItemGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
 		<Content Include="..\libs\x64\*.dll">
 			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>
-	<ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
+	<ItemGroup Condition="$([MSBuild]::IsOsPlatform('Linux'))">
 		<Content Include="..\libs\lib64\*.*">
 			<Link>lib64\%(RecursiveDir)%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+		<Content Include="..\libs\osx\*.dylib">
+      <!-- NB: these are x86-64 libs; your build script muse use an x64 dotnet install -->
+			<Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
 	</ItemGroup>

--- a/setup.sh
+++ b/setup.sh
@@ -19,22 +19,25 @@ git submodule update --init --remote --recursive
 echo -e "What is your project name?"
 read name
 
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/FNAECSTemplate.csproj
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate.sln
-sed -i -e "s/FNAECSTemplate/${name}/g" .vscode/launch.json
-sed -i -e "s/FNAECSTemplate/${name}/g" .vscode/tasks.json
-sed -i -e "s/Game1/${name}/g" FNAECSTemplate/Game1.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Game1.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Systems/ExampleSystem.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Components/Components.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Messages/Messages.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Relations/Relations.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Renderers/ExampleRenderer.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Utility/InputHelper.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Systems/Input.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Utility/Rando.cs
-sed -i -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Content.cs
+# BSD sed (macOS) requres a backup extension for sed when using -i
+# gnu sed (linux) requires no space between -i and the extension
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/FNAECSTemplate.csproj
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate.sln
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" .vscode/launch.json
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" .vscode/tasks.json
+sed -i'.temp-bak' -e "s/Game1/${name}/g" FNAECSTemplate/Game1.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Game1.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Systems/ExampleSystem.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Components/Components.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Messages/Messages.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Relations/Relations.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Renderers/ExampleRenderer.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Utility/InputHelper.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Systems/Input.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Utility/Rando.cs
+sed -i'.temp-bak' -e "s/FNAECSTemplate/${name}/g" FNAECSTemplate/Content.cs
 
+find . -name "*.temp-bak" -type f -delete
 
 mv "FNAECSTemplate.sln" "${name}.sln"
 mv "FNAECSTemplate/FNAECSTemplate.csproj" "FNAECSTemplate/${name}.csproj"


### PR DESCRIPTION
- update the sed args to work with both bsd sed (macos, freebsd etc) and gnu sed (linux (and therefore git-bash on windows))
- use the shiny new MSBuild property function for determining the host OS and include the appropriate fnalibs in the build directory
- spend about 4 hours in tears, literally pounding my chair with my fists in futile frustration before realizing that I am in fact the monster for having installed the arm64 version of the dotnet cli and sdk instead of the x64 versions about 2 millennia ago